### PR TITLE
Add error validation for sign in screen form

### DIFF
--- a/ios-target-app.xcodeproj/project.pbxproj
+++ b/ios-target-app.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		7EAFD83C28DC8C96002B4046 /* NetworkState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAFD83B28DC8C96002B4046 /* NetworkState.swift */; };
 		7EAFD83E28DC90A9002B4046 /* AuthViewModelStateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAFD83D28DC90A9002B4046 /* AuthViewModelStateDelegate.swift */; };
 		7EAFD84428DCBC14002B4046 /* SessionHeadersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAFD84328DCBC14002B4046 /* SessionHeadersProvider.swift */; };
+		7EC6268A28E732BE00554CAA /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC6268928E732BE00554CAA /* ColorExtension.swift */; };
 		7EE6300A28DDB9A300858594 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE6300928DDB9A300858594 /* Session.swift */; };
 		7EE6300C28DDBB6100858594 /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE6300B28DDBB6100858594 /* SignUpViewModel.swift */; };
 		7EE6300F28DDBEC500858594 /* AuthenticationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE6300E28DDBEC500858594 /* AuthenticationServices.swift */; };
@@ -87,6 +88,7 @@
 		7EAFD83B28DC8C96002B4046 /* NetworkState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkState.swift; sourceTree = "<group>"; };
 		7EAFD83D28DC90A9002B4046 /* AuthViewModelStateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModelStateDelegate.swift; sourceTree = "<group>"; };
 		7EAFD84328DCBC14002B4046 /* SessionHeadersProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHeadersProvider.swift; sourceTree = "<group>"; };
+		7EC6268928E732BE00554CAA /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		7EE6300928DDB9A300858594 /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		7EE6300B28DDBB6100858594 /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
 		7EE6300E28DDBEC500858594 /* AuthenticationServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServices.swift; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				7EEDF2B828CFD416009BE3A5 /* StringExtension.swift */,
 				7EAFD82428DA09BE002B4046 /* ImageViewExtension.swift */,
 				7EAFD83528DB905E002B4046 /* DictionaryExtension.swift */,
+				7EC6268928E732BE00554CAA /* ColorExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -661,6 +664,7 @@
 				7EE6302328E4BE4A00858594 /* HomeRoutes.swift in Sources */,
 				7EAFD83E28DC90A9002B4046 /* AuthViewModelStateDelegate.swift in Sources */,
 				7EAFD83C28DC8C96002B4046 /* NetworkState.swift in Sources */,
+				7EC6268A28E732BE00554CAA /* ColorExtension.swift in Sources */,
 				7EE6301228DDC37200858594 /* AuthEndpoint.swift in Sources */,
 				7EEDF2A528CB98CD009BE3A5 /* ViewExtension.swift in Sources */,
 				7EAFD83A28DC8C2D002B4046 /* User.swift in Sources */,

--- a/ios-target-app/Assets.xcassets/errorColor.colorset/Contents.json
+++ b/ios-target-app/Assets.xcassets/errorColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.162",
+          "green" : "0.164",
+          "red" : "0.921"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.162",
+          "green" : "0.164",
+          "red" : "0.921"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-target-app/Extensions/ColorExtension.swift
+++ b/ios-target-app/Extensions/ColorExtension.swift
@@ -8,5 +8,5 @@
 import UIKit
 
 extension UIColor {
-    static let errorColor = UIColor(named: "errorColor")!
+    static let error = UIColor(named: "errorColor")!
 }

--- a/ios-target-app/Extensions/ColorExtension.swift
+++ b/ios-target-app/Extensions/ColorExtension.swift
@@ -1,0 +1,12 @@
+//
+//  ColorExtension.swift
+//  ios-target-app
+//
+//  Created by Raul Piñeres Carrera on 30/09/22.
+//
+
+import UIKit
+
+extension UIColor {
+    static let errorColor = UIColor(named: "errorColor")!
+}

--- a/ios-target-app/Helpers/UIConstants.swift
+++ b/ios-target-app/Helpers/UIConstants.swift
@@ -18,6 +18,7 @@ struct UI {
     static let height: CGFloat = 55.0
     static let width: CGFloat = 80.0
     static let spacing: CGFloat = 8.0
+    static let errorBorderWidth: CGFloat = 2.0
   }
   
   enum Button {

--- a/ios-target-app/Helpers/UIConstants.swift
+++ b/ios-target-app/Helpers/UIConstants.swift
@@ -26,6 +26,8 @@ struct UI {
     static let height: CGFloat = 55.0
     static let width: CGFloat = 128.0
     static let spacing: CGFloat = 20.0
+    static let enabledAlpha: CGFloat = 1
+    static let disabledAlpha: CGFloat = 0.5
   }
   
   enum OvalImageView {

--- a/ios-target-app/Onboarding/ViewModels/SignInViewModel.swift
+++ b/ios-target-app/Onboarding/ViewModels/SignInViewModel.swift
@@ -25,11 +25,16 @@ class SignInViewModel {
     self.authServices = authServices
   }
   
-  private var state: AuthViewModelState = .network(state: .idle) {
+  /*
+   private var state: AuthViewModelState = .network(state: .idle) {
     didSet {
       delegate?.didUpdateState(to: state)
     }
-  }
+  } */
+  
+  @Published private var state: AuthViewModelState = .network(state: .idle)
+  
+  var statePublisher: Published<AuthViewModelState>.Publisher { $state }
   
   weak var delegate: SignInViewModelDelegate?
   
@@ -45,7 +50,7 @@ class SignInViewModel {
     }
   }
   
-  var hasValidData: Bool {
+  var hasValidCredentials: Bool {
     email.isEmailFormatted() && !password.isEmpty
   }
   
@@ -76,4 +81,3 @@ class SignInViewModel {
     }
   }
 }
-

--- a/ios-target-app/Onboarding/ViewModels/SignInViewModel.swift
+++ b/ios-target-app/Onboarding/ViewModels/SignInViewModel.swift
@@ -25,16 +25,13 @@ class SignInViewModel {
     self.authServices = authServices
   }
   
-  /*
-   private var state: AuthViewModelState = .network(state: .idle) {
-    didSet {
-      delegate?.didUpdateState(to: state)
-    }
-  } */
-  
   @Published private var state: AuthViewModelState = .network(state: .idle)
   
   var statePublisher: Published<AuthViewModelState>.Publisher { $state }
+  
+  @Published private var isSignInEnabled: Bool = false
+  
+  var isSignInEnabledPublisher: Published<Bool>.Publisher { $isSignInEnabled }
   
   weak var delegate: SignInViewModelDelegate?
   
@@ -79,5 +76,9 @@ class SignInViewModel {
     case .password:
       self.password = value
     }
+  }
+  
+  func setSignInButtonStatus() {
+    self.isSignInEnabled = hasValidCredentials
   }
 }

--- a/ios-target-app/Onboarding/ViewModels/SignInViewModel.swift
+++ b/ios-target-app/Onboarding/ViewModels/SignInViewModel.swift
@@ -73,12 +73,10 @@ class SignInViewModel {
     switch field {
     case .email:
       self.email = value
+      self.isSignInEnabled = hasValidCredentials
     case .password:
       self.password = value
+      self.isSignInEnabled = hasValidCredentials
     }
-  }
-  
-  func setSignInButtonStatus() {
-    self.isSignInEnabled = hasValidCredentials
   }
 }

--- a/ios-target-app/Onboarding/Views/SignInViewController.swift
+++ b/ios-target-app/Onboarding/Views/SignInViewController.swift
@@ -46,7 +46,7 @@ class SignInViewController: UIViewController {
   
   private lazy var credentialsErrorLabel = UILabel(
     text: "sign_in_error_label".localized,
-    textColor: .errorColor,
+    textColor: .error,
     size: .small
   )
   
@@ -120,7 +120,7 @@ class SignInViewController: UIViewController {
     viewModel.statePublisher
       .receive(on: RunLoop.main)
       .sink { [weak self] state in
-        self?.setViewsStatus(state: state)
+        self?.setViewsState(state: state)
       }.store(in: &subscribers)
     
     viewModel.isSignInEnabledPublisher
@@ -130,7 +130,7 @@ class SignInViewController: UIViewController {
       }.store(in: &subscribers)
   }
   
-  private func setViewsStatus(state: AuthViewModelState) {
+  private func setViewsState(state: AuthViewModelState) {
     switch state {
     case .loggedIn: break
       // TODO: add action
@@ -141,7 +141,7 @@ class SignInViewController: UIViewController {
       case .loading: break
         // TODO: add action
       case .error(_):
-        setErrorStatusToViews()
+        setErrorStateToViews()
       }
     }
   }
@@ -186,11 +186,11 @@ class SignInViewController: UIViewController {
     ])
   }
   
-  private func setErrorStatusToViews() {
+  private func setErrorStateToViews() {
     credentialsErrorLabel.isHidden = false
-    emailField.layer.borderColor = UIColor.errorColor.cgColor
+    emailField.layer.borderColor = UIColor.error.cgColor
     emailField.layer.borderWidth = UI.TextField.errorBorderWidth
-    passwordField.layer.borderColor = UIColor.errorColor.cgColor
+    passwordField.layer.borderColor = UIColor.error.cgColor
     passwordField.layer.borderWidth = UI.TextField.errorBorderWidth
   }
   
@@ -213,10 +213,8 @@ class SignInViewController: UIViewController {
     switch sender {
     case emailField:
       viewModel.fieldChanged(field: .email, value: newValue)
-      viewModel.setSignInButtonStatus()
     case passwordField:
       viewModel.fieldChanged(field: .password, value: newValue)
-      viewModel.setSignInButtonStatus()
     default: break
     }
   }

--- a/ios-target-app/Onboarding/Views/SignInViewController.swift
+++ b/ios-target-app/Onboarding/Views/SignInViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Raul Piñeres Carrera on 8/09/22.
 //
 
+import Combine
 import UIKit
 
 class SignInViewController: UIViewController {
@@ -41,6 +42,12 @@ class SignInViewController: UIViewController {
     selector: #selector(formEditingChange),
     placeholder: "sign_in_password_placeholder".localized,
     isPassword: true
+  )
+  
+  private lazy var credentialsErrorLabel = UILabel(
+    text: "sign_in_error_label".localized,
+    textColor: .errorColor,
+    size: .small
   )
   
   private lazy var signInButton = UIButton(
@@ -86,6 +93,8 @@ class SignInViewController: UIViewController {
   init(viewModel: SignInViewModel) {
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
+    
+    setupSubscribers()
   }
   
   @available(*, unavailable)
@@ -104,11 +113,40 @@ class SignInViewController: UIViewController {
     navigationController?.setNavigationBarHidden(true, animated: animated)
   }
   
+  // MARK: - Subscribers
+  private var subscribers: Set<AnyCancellable> = []
+  
+  private func setupSubscribers() {
+    viewModel.statePublisher
+      .receive(on: RunLoop.main)
+      .sink { [weak self] state in
+        self?.setViewsStatus(state: state)
+      }.store(in: &subscribers)
+  }
+  
+  private func setViewsStatus(state: AuthViewModelState) {
+    switch state {
+    case .loggedIn: break
+      // TODO: add action
+    case .network(state: let state):
+      switch state {
+      case .idle: break
+        // TODO: add action
+      case .loading: break
+        // TODO: add action
+      case .error(_):
+        setErrorStatusToViews()
+      }
+    }
+  }
+  
+  // MARK: - Views configurations
   private func setViews() {
     view.addSubviews([ovalsImageView, scrollView])
     view.backgroundColor = .white
     scrollView.addSubview(stackView)
     lineView.setToLineView()
+    credentialsErrorLabel.isHidden = true
     
     setContainerLayouts()
   }
@@ -128,6 +166,7 @@ class SignInViewController: UIViewController {
       emailField,
       passwordLabel,
       passwordField,
+      credentialsErrorLabel,
       signInButton,
       forgotPasswordButton,
       connectFacebookButton,
@@ -141,7 +180,15 @@ class SignInViewController: UIViewController {
     ])
   }
   
-  // HANDLE NAVIGATION AND ACTIONS
+  private func setErrorStatusToViews() {
+    credentialsErrorLabel.isHidden = false
+    emailField.layer.borderColor = UIColor.errorColor.cgColor
+    emailField.layer.borderWidth = UI.TextField.errorBorderWidth
+    passwordField.layer.borderColor = UIColor.errorColor.cgColor
+    passwordField.layer.borderWidth = UI.TextField.errorBorderWidth
+  }
+  
+  // MARK: - Navigation and Actions
   @objc func signInButtonTapped() {
     viewModel.signIn()
   }

--- a/ios-target-app/Onboarding/Views/SignInViewController.swift
+++ b/ios-target-app/Onboarding/Views/SignInViewController.swift
@@ -122,6 +122,12 @@ class SignInViewController: UIViewController {
       .sink { [weak self] state in
         self?.setViewsStatus(state: state)
       }.store(in: &subscribers)
+    
+    viewModel.isSignInEnabledPublisher
+      .receive(on: RunLoop.main)
+      .sink { [weak self] isButtonEnabled in
+        self?.setSignInButton(enabled: isButtonEnabled)
+      }.store(in: &subscribers)
   }
   
   private func setViewsStatus(state: AuthViewModelState) {
@@ -188,6 +194,11 @@ class SignInViewController: UIViewController {
     passwordField.layer.borderWidth = UI.TextField.errorBorderWidth
   }
   
+  func setSignInButton(enabled: Bool) {
+    signInButton.alpha = enabled ? UI.Button.enabledAlpha : UI.Button.disabledAlpha
+    signInButton.isEnabled = enabled
+  }
+  
   // MARK: - Navigation and Actions
   @objc func signInButtonTapped() {
     viewModel.signIn()
@@ -202,8 +213,10 @@ class SignInViewController: UIViewController {
     switch sender {
     case emailField:
       viewModel.fieldChanged(field: .email, value: newValue)
+      viewModel.setSignInButtonStatus()
     case passwordField:
       viewModel.fieldChanged(field: .password, value: newValue)
+      viewModel.setSignInButtonStatus()
     default: break
     }
   }

--- a/ios-target-app/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios-target-app/Resources/Localization/en.lproj/Localizable.strings
@@ -25,3 +25,4 @@
 "sign_in_button" = "SIGN IN";
 "sign_in_forgot_password" = "Forgot your password?";
 "sign_in_connect_facebook" = "CONNECT WITH FACEBOOK";
+"sign_in_error_label" = "This email and password don’t match";


### PR DESCRIPTION
- Add Publisher to sign in ViewModel.
- Set subscribers on Sign In screen to listen form validation.
- Add error color Asset.
- Add color extension
- Add Sign In button status validation based on form format validation.

Video demo:

https://user-images.githubusercontent.com/112905642/193643893-4a7db97e-2526-40d3-87d2-de9affa368f8.mov


